### PR TITLE
 Enhance supabase.extended.ts to include FunctionExtensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Here's the solution: An easy way to adapt the derived types and having fully typ
 1. You generate the types at `supabase.ts`
 1. You copy the file `supabase.extended.ts` to the same directory
 1. You adapt `TableExtensions` to your likings
+1. You adapt `FunctionExtensions` to your likings
 1. You `import { Database } from './supabase.extended`
 1. You instantiate a client with `createClient<Database>` from the previous import (of the extended file, not the `supabase.ts`)
 

--- a/supabase.extended.ts
+++ b/supabase.extended.ts
@@ -1,6 +1,8 @@
 import { Database as PostgresSchema } from './supabase';
 
 type PostgresTables = PostgresSchema['public']['Tables'];
+type PostgresFunctions = PostgresSchema['public']['Functions'];
+
 
 // THIS IS THE ONLY THING YOU EDIT
 // <START>
@@ -17,6 +19,18 @@ type TableExtensions = {
 };
 // <END>
 // ☝️ this is the only thing you edit
+
+type FunctionsExtensions = {
+  /**
+	my_existing_function: {
+		my_json_argument: {
+			id: string;
+			name: string;
+			test: number[];
+		};
+	};
+  */
+};
 
 type TakeDefinitionFromSecond<T extends object, P extends object> = Omit<
   T,
@@ -49,15 +63,29 @@ type NewTables = {
   };
 };
 
+type NewFunctions = {
+	[k in keyof PostgresFunctions]: {
+		Args: k extends keyof FunctionsExtensions
+			? TakeDefinitionFromSecond<PostgresFunctions[k]['Args'], FunctionsExtensions[k]>
+			: PostgresFunctions[k]['Args'];
+		Returns: PostgresFunctions[k]['Returns'];
+	};
+};
+
 export type Database = {
-  public: Omit<PostgresSchema['public'], 'Tables'> & {
-    Tables: NewTables;
-  };
+	public: Omit<PostgresSchema['public'], 'Tables' | 'Functions'> & {
+		Tables: NewTables;
+		Functions: NewFunctions;
+	};
 };
 
 export type TableName = keyof Database['public']['Tables'];
 export type TableRow<T extends TableName> =
   Database['public']['Tables'][T]['Row'];
+
+export type FunctionName = keyof Database['public']['Functions'];
+export type FunctionArgs<T extends FunctionName> =
+Database['public']['Functions'][T]['Args'];
 
 export type TableView<View extends keyof Database['public']['Views']> =
   Database['public']['Views'][View]['Row'];


### PR DESCRIPTION
In this PR, I add a FunctionExtensions type to override RPC function arguments. 

In a project I am working on, I utilize JSONB arguments for a few of my functions. While I'm not sure if this is the best thing to do (as opposed to specific each argument instead of lumping it all into a JSONB argument), Supabase-generated types do not give type sense on what that JSON's schema should be like. 